### PR TITLE
Bump setup-node and cache actions to v4 to prevent warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
     - name: Cache Solana CLI tools
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/solana/


### PR DESCRIPTION
Fixes `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.` warning.